### PR TITLE
fix randomly_gen_uspace_url function

### DIFF
--- a/hostloc_get_points.py
+++ b/hostloc_get_points.py
@@ -6,13 +6,8 @@ import re
 
 
 def randomly_gen_uspace_url():
-    url_list = []
-    # 生成的随机数可能会重复，懒得去重了，多生成几个就行了
-    for i in range(12):
-        uid = random.randint(10000, 35000)
-        url = "https://www.hostloc.com/space-uid-{}.html".format(str(uid))
-        url_list.append(url)
-    return url_list
+    uid_list = random.sample(range(10000,35000),12)
+    return list(map(lambda n:"https://www.hostloc.com/space-uid-{}.html".format(str(n)), uid_list))
 
 
 def login(username, password):

--- a/hostloc_get_points.py
+++ b/hostloc_get_points.py
@@ -5,9 +5,9 @@ import random
 import re
 
 
-def randomly_gen_uspace_url():
-    uid_list = random.sample(range(10000,35000),12)
-    return list(map(lambda n:"https://www.hostloc.com/space-uid-{}.html".format(str(n)), uid_list))
+def randomly_gen_uspace_url(num):
+    uid_list = random.sample(range(10000,35000),num)
+    return list(map(lambda id:"https://www.hostloc.com/space-uid-{}.html".format(str(id)), uid_list))
 
 
 def login(username, password):
@@ -41,7 +41,7 @@ def check_login_status(s, number_c):
 
 def get_points(s, number_c):
     if check_login_status(s, number_c):
-        url_list = randomly_gen_uspace_url()
+        url_list = randomly_gen_uspace_url(10)
         for url in url_list:
             try:
                 s.get(url)


### PR DESCRIPTION
使用random.sample保证生成的随机数不重复。

我用自己的仓库测试了一下，好像是没问题的。